### PR TITLE
Add support for hbmenu 0.6/newer HB SRLs...

### DIFF
--- a/exploits/minitwlpayload/bootloader/source/boot.c
+++ b/exploits/minitwlpayload/bootloader/source/boot.c
@@ -56,6 +56,7 @@ void arm7clearRAM();
 //+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 // Important things
 #define TEMP_MEM 0x02FFE000
+#define TWL_HEAD 0x02FFE000
 #define NDS_HEAD 0x02FFFE00
 #define TEMP_ARM9_START_ADDRESS (*(vu32*)0x02FFFFF4)
 
@@ -65,6 +66,10 @@ const char* bootName = "BOOT.NDS";
 extern unsigned long _start;
 extern unsigned long argStart;
 extern unsigned long argSize;
+
+// Manually define as true. DSI exploits always run in DSi mode.
+// Will return as undefined during compile if not defined this way. (with current setup)
+bool dsiMode = true;
 
 #ifdef USE_FIRMWARE_READ
 //++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -121,9 +126,26 @@ void passArgs_ARM7 (void) {
 	
 	if (!argStart || !argSize) return;
 	
+	if ( ARM9_DST == 0 && ARM9_LEN == 0) {
+		ARM9_DST = *((u32*)(NDS_HEAD + 0x038));
+		ARM9_LEN = *((u32*)(NDS_HEAD + 0x03C));
+	}
+	
 	argSrc = (u32*)(argStart + (int)&_start);
 	
 	argDst = (u32*)((ARM9_DST + ARM9_LEN + 3) & ~3);		// Word aligned 
+	
+	if (dsiMode && (*(u8*)(NDS_HEAD + 0x012) & BIT(1)))
+	{
+		u32 ARM9i_DST = *((u32*)(TWL_HEAD + 0x1C8));
+		u32 ARM9i_LEN = *((u32*)(TWL_HEAD + 0x1CC));
+		if (ARM9i_LEN)
+		{
+			u32* argDst2 = (u32*)((ARM9i_DST + ARM9i_LEN + 3) & ~3);		// Word aligned
+			if (argDst2 > argDst)
+				argDst = argDst2;
+		}
+	}
 	
 	copyLoop(argDst, argSrc, argSize);
 	
@@ -226,6 +248,24 @@ void loadBinary_ARM7 (u32 fileCluster)
 	TEMP_ARM9_START_ADDRESS = ndsHeader[0x024>>2];		// Store for later
 	ndsHeader[0x024>>2] = 0;
 	dmaCopyWords(3, (void*)ndsHeader, (void*)NDS_HEAD, 0x170);
+
+	if (dsiMode && (ndsHeader[0x10>>2]&BIT(16+1)))
+	{
+		// Read full TWL header
+		fileRead((char*)TWL_HEAD, fileCluster, 0, 0x1000);
+
+		u32 ARM9i_SRC = *(u32*)(TWL_HEAD+0x1C0);
+		char* ARM9i_DST = (char*)*(u32*)(TWL_HEAD+0x1C8);
+		u32 ARM9i_LEN = *(u32*)(TWL_HEAD+0x1CC);
+		u32 ARM7i_SRC = *(u32*)(TWL_HEAD+0x1D0);
+		char* ARM7i_DST = (char*)*(u32*)(TWL_HEAD+0x1D8);
+		u32 ARM7i_LEN = *(u32*)(TWL_HEAD+0x1DC);
+
+		if (ARM9i_LEN)
+			fileRead(ARM9i_DST, fileCluster, ARM9i_SRC, ARM9i_LEN);
+		if (ARM7i_LEN)
+			fileRead(ARM7i_DST, fileCluster, ARM7i_SRC, ARM7i_LEN);
+	}
 }
 
 /*-------------------------------------------------------------------------

--- a/exploits/minitwlpayload/bootloader/source/boot.c
+++ b/exploits/minitwlpayload/bootloader/source/boot.c
@@ -66,10 +66,7 @@ const char* bootName = "BOOT.NDS";
 extern unsigned long _start;
 extern unsigned long argStart;
 extern unsigned long argSize;
-
-// Manually define as true. DSI exploits always run in DSi mode.
-// Will return as undefined during compile if not defined this way. (with current setup)
-static const int dsiMode = 1;
+extern unsigned long dsiMode;
 
 #ifdef USE_FIRMWARE_READ
 //++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/exploits/minitwlpayload/bootloader/source/boot.c
+++ b/exploits/minitwlpayload/bootloader/source/boot.c
@@ -55,7 +55,7 @@ void arm7clearRAM();
 
 //+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 // Important things
-#define TEMP_MEM 0x02FFE000
+#define TEMP_MEM 0x02FFD000
 #define TWL_HEAD 0x02FFE000
 #define NDS_HEAD 0x02FFFE00
 #define TEMP_ARM9_START_ADDRESS (*(vu32*)0x02FFFFF4)
@@ -69,7 +69,7 @@ extern unsigned long argSize;
 
 // Manually define as true. DSI exploits always run in DSi mode.
 // Will return as undefined during compile if not defined this way. (with current setup)
-bool dsiMode = true;
+static const int dsiMode = 1;
 
 #ifdef USE_FIRMWARE_READ
 //++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/exploits/minitwlpayload/bootloader/source/load_crt0.s
+++ b/exploits/minitwlpayload/bootloader/source/load_crt0.s
@@ -25,6 +25,7 @@
 	.global _start
 	.global argStart
 	.global argSize
+	.global dsiMode
 @---------------------------------------------------------------------------------
 	.align	4
 	.arm
@@ -38,6 +39,8 @@ argStart:
 	.word	_end - _start
 argSize:
 	.word	0x00000000
+dsiMode:
+	.word	1
 
 startUp:
 	mov	r0, #0x04000000


### PR DESCRIPTION
I tested this and appears to work. Adds missing code in boot.c to handle newer homebrew SRLs that are compiled on newer versions of libnds that have moved DSi code to DSi arm7i/arm9i binaries.

Exploit games that rely only on minitwlpayload should support hbmenu 0.6 and similar hb SRLs now.

Code copied from hbmenu 0.6's bootloader boot.c.

I had to manually define dsiMode mode as a bool and set it to true so any code that checks it will always return that as true. Perhaps there is a better way of implementing that but right now none of the games that run this payload will ever be running in NTR mode, so it isn't really going to break anything. :P