### PR TITLE
Restored FAT12/16 support in minitwlpayload.

### DIFF
--- a/exploits/4swordshax/4swordshax.s
+++ b/exploits/4swordshax/4swordshax.s
@@ -170,9 +170,6 @@ bx lr
 #define ICACHE_SIZE	0x2000
 #define DCACHE_SIZE	0x1000
 #define CACHE_LINE_SIZE	32
-#define ICACHE_SIZE	0x2000
-#define DCACHE_SIZE	0x1000
-#define CACHE_LINE_SIZE	32
 
 DC_FlushAll: @ From libnds, write buffer draining code was added by yellows8.
 /*---------------------------------------------------------------------------------

--- a/exploits/minitwlpayload/bootloader/source/arm9clear.arm.c
+++ b/exploits/minitwlpayload/bootloader/source/arm9clear.arm.c
@@ -12,14 +12,14 @@
 #include <nds/arm9/input.h>
 
 #include "boot.h"
-
+/* Disabled debug drawing code. This causes a jump to empty vram error.
 static inline void debug_color(int r, int g, int b)
 {
 	u16 clr = RGB15(r,g,b);
 	*(vu32*)0x05000000 = clr;
 	*(vu32*)0x05000400 = clr;
 }
-
+*/
 /*-------------------------------------------------------------------------
 resetMemory2_ARM9
 Clears the ARM9's DMA channels and resets video memory
@@ -29,12 +29,13 @@ Modified by Chishm:
 --------------------------------------------------------------------------*/
 void __attribute__ ((long_call)) __attribute__((naked)) __attribute__((noreturn)) resetMemory2_ARM9 (void) 
 {
- 	register int i, reg;
+ 	register int i;
+	/*
 	if (*(vu32*)(0x02FFE000-4))
 		debug_color(0,0,31); // blue
 	else
 		debug_color(31,15,15); // light red
-  
+	*/
 	//clear out ARM9 DMA channels
 	/* --removed-- already done by other code
 	for (i=0; i<4; i++) {
@@ -99,7 +100,7 @@ Modified by Chishm:
 --------------------------------------------------------------------------*/
 void __attribute__ ((long_call)) __attribute__((noreturn)) __attribute__((naked)) startBinary_ARM9 (void)
 {
-	debug_color(15,15,31); // light blue
+	// debug_color(15,15,31); // light blue
 	REG_IME=0;
 	REG_EXMEMCNT = 0xE880;
 	// set ARM9 load address to 0 and wait for it to change again

--- a/exploits/minitwlpayload/bootloader/source/fat.c
+++ b/exploits/minitwlpayload/bootloader/source/fat.c
@@ -216,7 +216,6 @@ u32 FAT_NextCluster(u32 cluster)
 	
 	switch (discFileSystem) 
 	{
-#ifdef SUPPORT_OLD_FAT
 		case FS_UNKNOWN:
 			nextCluster = CLUSTER_FREE;
 			break;
@@ -257,7 +256,6 @@ u32 FAT_NextCluster(u32 cluster)
 				nextCluster = CLUSTER_EOF;
 			}
 			break;
-#endif
 			
 		case FS_FAT32:
 			sector = discFAT + ((cluster << 2) / BYTES_PER_SECTOR);
@@ -585,3 +583,4 @@ u32 fileRead (char* buffer, u32 cluster, u32 startOffset, u32 length)
 	
 	return dataPos;
 }
+

--- a/exploits/minitwlpayload/source/exploit.c
+++ b/exploits/minitwlpayload/source/exploit.c
@@ -5,17 +5,17 @@ static void resetArm9();
 static void bootstrapArm7();
 static void bootstrapArm7DSiSync();
 static int sendipcmsg(u32 channel, u32 data);
-
+/* Disabled debug code. This causes a jump to empty vram error.
 static inline void debug_color(int r, int g, int b)
 {
 	u16 clr = RGB15(r,g,b);
 	*(vu32*)0x05000000 = clr;
 	*(vu32*)0x05000400 = clr;
 }
-
+*/
 int main(void)
 {
-	debug_color(31,15,0); // orange
+	// debug_color(31,15,0); // orange
 
 	resetArm9();
 	bootstrapArm7();
@@ -68,18 +68,18 @@ void bootstrapArm7()
 	NDSHEADER->arm7executeAddress = 0x06000000;
 
 	while(sendipcmsg(12, 0x10<<8)<0);
-	debug_color(31,31,0); // yellow
+	// debug_color(31,31,0); // yellow
 
 	bootstrapArm7DSiSync();
 	while(IPC_GetSync()!=1);
 
-	debug_color(31,0,31); // magenta
+	// debug_color(31,0,31); // magenta
 
 	VRAM_C_CR = VRAM_ENABLE | VRAM_C_LCD;
 	memcpy16(VRAM_C, ndsloader_bin, ndsloader_bin_size);
 	VRAM_C_CR = VRAM_ENABLE | VRAM_C_ARM7_0x06000000;
 
-	debug_color(0,15,0); // dark green
+	// debug_color(0,15,0); // dark green
 
 	IPC_SendSync(1);
 
@@ -87,9 +87,9 @@ void bootstrapArm7()
 
 	IPC_SendSync(0);
 
-	debug_color(0,31,0); // green
+	// debug_color(0,31,0); // green
 	while (BOOTFLAG != 42);
-	debug_color(15,31,15); // bright green
+	// debug_color(15,31,15); // bright green
 
 	swiSoftReset();
 	__builtin_unreachable();


### PR DESCRIPTION
Also cleaned up a couple warnings. There is duplicate define code in
4swordshax.s and an unused "reg" in arm9clear.arm.c

Code for drawing color on screen for debug doesn't play nice with this
(causes a jump to empty vram crash). So it has been disabled in
minitwlpayload. Tested on both FAT32 and FAT16 on hardware. It works.

You can add the debug color back if you can get it to get along (payload still fits in 4swordshax save either way) but I don't know enough to know why it was happening.

It was the DLDI code that bloats the payload size. minitwlpayload already had this removed so re-enabling fat16 did not cause issues with the size of the payload.

I guess you forgot to test with FAT16 code after stripping the DLDI stuff? lol

This payload even works in our other exploit now so no more need of replacing the fat.c entirely.